### PR TITLE
derive_from for empty enum variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_wrapper"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ enum MyEnum<T> {
     },
     #[derive_from]
     Fifth(PhantomData<T>),
+    #[derive_from(f32, f64)]
+    Floats,
 }
 ```

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -4,6 +4,7 @@
 extern crate derive_wrapper;
 use std::convert::AsRef;
 use std::error::Error;
+use std::io::{self, Empty};
 use std::marker::PhantomData;
 
 #[derive(AsRef, Default, Display, Debug, PartialEq)]
@@ -51,6 +52,8 @@ enum Hi<T> {
     },
     #[derive_from]
     Fifth(PhantomData<T>),
+    #[derive_from(Empty, f32)]
+    Seventh,
 }
 
 //#[derive(AsRef)]
@@ -91,6 +94,12 @@ fn test_from_enum() {
 
         let fifth: Hi<()> = Hi::from(PhantomData);
         assert_eq!(fifth, Hi::Fifth(PhantomData));
+
+        let seventh1: Hi<()> = Hi::from(io::empty());
+        assert_eq!(seventh1, Hi::Seventh);
+
+        let seventh2: Hi<()> = Hi::from(52.4f32);
+        assert_eq!(seventh2, Hi::Seventh);
     }
 }
 
@@ -186,6 +195,8 @@ fn test_readme() {
         },
         #[derive_from]
         Fifth(PhantomData<T>),
+        #[derive_from(f32, f64)]
+        Floats,
     }
 }
 


### PR DESCRIPTION
This should fix #3.
Full path types aren't supported because they're not supported in pre1.0 syn. (Not 100% sure they're supported after, but seems like they might be)