### PR TITLE
Better derive_from, to support paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_wrapper"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Elichai Turkel <elichai.turkel@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -46,5 +46,8 @@ enum MyEnum<T> {
     Fifth(PhantomData<T>),
     #[derive_from(f32, f64)]
     Floats,
+    #[derive_from(std::io::Error, std::fmt::Error)]
+    Errors,
+
 }
 ```

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -52,7 +52,7 @@ enum Hi<T> {
     },
     #[derive_from]
     Fifth(PhantomData<T>),
-    #[derive_from(Empty, f32)]
+    #[derive_from(Empty, f32, io::Error)]
     Seventh,
 }
 
@@ -64,6 +64,12 @@ enum Hi<T> {
 //
 //#[derive(AsRef)]
 //struct Fail2;
+
+// #[derive(From)]
+// enum Fail3 {
+//     #[wrap]
+//     Yo,
+// }
 
 fn test_from() {
     let a: One = [55u8; 32].into();
@@ -197,6 +203,8 @@ fn test_readme() {
         Fifth(PhantomData<T>),
         #[derive_from(f32, f64)]
         Floats,
+        #[derive_from(std::io::Error, std::fmt::Error)]
+        Errors,
     }
 }
 


### PR DESCRIPTION
This fixes this problem:
https://github.com/elichai/derive-wrapper/issues/3#issuecomment-616462435

Before you could only do:
```rust
use std::io::Error as IoError;
use std::fmt::Error as FmtError;
#[derive(From)]
enum Test {
   #[derive_from(IoError, FmtEror)]
    First
}
```
Now you can do:
```rust
#[derive(From)]
enum Test {
   #[derive_from(std::io::Error, std::fmt::Error)]
    First
}
```

@dr-orlovsky Can you test that:
A. it works.
B. it shouldn't be a breaking change (your current use should still compile)