### PR TITLE
Allowing unknown attributes

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -44,6 +44,8 @@ enum Hi<T> {
     /// Docstring
     #[derive_from]
     First(u8),
+    // Here we test that all other attributes are allowed
+    #[cfg(not(MSRV))]
     #[derive_from]
     Second(Heap),
     Third,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,14 +165,6 @@ fn from_inner_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream2>
                         }
                     };
                 }
-            } else if attr.path.is_ident("doc") {
-                // Do nothing here
-            } else {
-                let attr_name = path_to_string(&attr.path);
-                return Err(Error::new_spanned(
-                    &attr,
-                    &format!("The `#[{}]` attribute is not supported in enums", attr_name),
-                ));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,22 +452,6 @@ fn extract_types_from_potential_tupled_attribute(attr: &Attribute) -> Result<Vec
     })
 }
 
-fn path_to_string(p: &Path) -> String {
-    let mut res = String::with_capacity(p.segments.len() * 6);
-    if p.leading_colon.is_some() {
-        res.push_str("::");
-    }
-    for segment in p.segments.iter() {
-        res.push_str(&segment.ident.to_string());
-        res.push_str("::");
-    }
-    if !p.segments.is_empty() {
-        let len = res.len() - 2;
-        res.truncate(len);
-    }
-    res
-}
-
 #[derive(Default)]
 struct MetaValue {
     pub found: bool,


### PR DESCRIPTION
Rust language takes care of the attributes which are not covered
by any existing proc_macro. Nevertheless, it's still important
to pass attributes which are not related to the current derive
macro. For instance, w/o it impossible to do such things as

```rust
#[derive(From)]
enum Error {
   #[derive_from]
   #[cfg(feature = "some")
   ErrorCase(OtherError)
}
```